### PR TITLE
2023 Day 5: If You Give A Seed A Fertilizer

### DIFF
--- a/2023/C#/code/Day5/Day5.cs
+++ b/2023/C#/code/Day5/Day5.cs
@@ -1,0 +1,109 @@
+
+public class Day5 : IDay, IDayPart1<double>, IDayPart2<double?>
+{
+    public IEnumerable<string> InputData { get; } = File.ReadLines(@".\data\day5\input.txt");
+
+    public IEnumerable<string> SampleData { get; } = File.ReadLines(@".\data\day5\sample.txt");
+
+    public double GetPart1Answer(IEnumerable<string> input)
+    {
+        var seeds = getSeeds(input.First());
+        var maps = getTranslationMaps(input.Skip(1));
+
+        return seeds.Aggregate(double.MaxValue, (lowest, seed) =>
+        {
+            var location = maps.Aggregate(seed, (current, translations) =>
+            {
+                // will either be a translation, or the default which will have 0 for mapValue
+                var matchedTranslation = translations.FirstOrDefault(t => t.Start <= current && current <= t.End);
+
+                return current + matchedTranslation.mapValue;
+            });
+
+            return Math.Min(location, lowest);
+        });
+    }
+
+    public double? GetPart2Answer(IEnumerable<string> input)
+    {
+        var seedRanges = input.First()[7..].Split(' ')
+            .Select(double.Parse)
+            .Chunk(2).Select(pair => (start: pair[0], end: pair[0] + pair[1] - 1));
+
+        var maps = getTranslationMaps(input.Skip(1));
+        
+        var location = maps.Aggregate(seedRanges, (ranges, translations) => {
+            // create new ranges based on translation
+            var outstandingRanges = new Queue<(double start, double end)>(ranges);
+            var translated = new List<(double start, double end)>();
+
+            while(outstandingRanges.Count > 0)
+            {
+                var range = outstandingRanges.Dequeue();
+                // get next matching translation
+                var nextTranslation = translations.FirstOrDefault(t => t.Start <= range.end && range.start <= t.End);
+
+                if (nextTranslation.Start == 0 && nextTranslation.End == 0)
+                {
+                    // no translation required, add as is
+                    translated.Add(range);
+                    continue;
+                }
+                
+                // add any portion outside the translation as an outstanding range
+                if (range.start < nextTranslation.Start)
+                {
+                    outstandingRanges.Enqueue((range.start, nextTranslation.Start - 1));
+                }
+
+                if (range.end > nextTranslation.End)
+                {
+                    outstandingRanges.Enqueue((nextTranslation.End + 1, range.end));
+                }
+                
+                // translate the portion within the range
+                translated.Add((
+                    Math.Max(range.start, nextTranslation.Start) + nextTranslation.mapValue,
+                    Math.Min(range.end, nextTranslation.End) + nextTranslation.mapValue
+                ));
+            }
+
+            return translated;
+        })
+        .MinBy(r => r.start);
+
+        return location.start;
+    }
+
+    private readonly record struct Translation(double Start, double End, double mapValue);
+
+    private IEnumerable<double> getSeeds(string line) => 
+        line[7..].Split(' ').Select(double.Parse);
+    
+    private IEnumerable<IEnumerable<Translation>> getTranslationMaps(IEnumerable<string> input) =>
+        input.Aggregate(new List<List<Translation>>(), (acc, line) => {
+            // divider, skip
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return acc;
+            }
+
+            // next category
+            if (line.EndsWith(':'))
+            {
+                acc.Add(new List<Translation>());
+                return acc;
+            }
+
+            // translation range
+            var digits = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var currentMap = acc.Last();
+
+            var destination = double.Parse(digits[0]);
+            var source = double.Parse(digits[1]);
+            var range = double.Parse(digits[2]) - 1;
+            currentMap.Add(new Translation(source, source + range, destination - source));
+
+            return acc;
+        });
+}

--- a/2023/C#/tests/Day5.cs
+++ b/2023/C#/tests/Day5.cs
@@ -1,0 +1,39 @@
+using Xunit;
+using FluentAssertions;
+
+public class Day5Tests
+{
+    Day5 _sut = new Day5();
+
+    [Fact]
+    public void Part1Answer_ShouldBeCorrect_WhenSampleData()
+    {
+        var answer = _sut.GetPart1Answer(_sut.SampleData);
+
+        answer.Should().Be(35);
+    }
+
+    [Fact]
+    public void Part1Answer_ShouldBeCorrect_WhenInputData()
+    {
+        var answer = _sut.GetPart1Answer(_sut.InputData);
+
+        answer.Should().Be(379811651);
+    }
+
+    [Fact]
+    public void Part2Answer_ShouldBeCorrect_WhenSampleData()
+    {
+        var answer = _sut.GetPart2Answer(_sut.SampleData);
+
+        answer.Should().Be(46);
+    }
+
+    [Fact]
+    public void Part2Answer_ShouldBeCorrect_WhenInputData()
+    {
+        var answer = _sut.GetPart2Answer(_sut.InputData);
+
+        answer.Should().Be(27992443);
+    } 
+}


### PR DESCRIPTION
First tricker puzzle of 2023 I found. This one is a classic AoC trope by now - part 1 can be done by creating a simple data structure/recursion pattern using the given inputs, but in Part 2 we are going to open the input space up to _astronomically_ so you'll need to think outside the box.

Thankfully this is somewhat similar to a puzzle from a previous year, so I recalled that the trick (or at least, how I did it) is to treat the inputs as _ranges_ rather than examine every possible seed within those ranges. By slicing each input range and transforming the start and end of the range, the only complexity was just handling portions of seed ranges that fell outside of any mappings for a given category. I'm sure you could do this using recursion, but since I have access to mutable structures and `while` directly I decided to simply use a queue and continue to process slices of ranges until everything had cleanly fell into a single mapping or matched none (and therefore required no mapping at this stage).