### PR TITLE
2023 Day 7: Camel Cards

### DIFF
--- a/2023/C#/code/Day7/Day7.cs
+++ b/2023/C#/code/Day7/Day7.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+
+public class Day7 : IDay, IDayPart1<int>, IDayPart2<int?>
+{
+    public IEnumerable<string> InputData { get; } = File.ReadLines(@".\data\day7\input.txt");
+
+    public IEnumerable<string> SampleData { get; } = File.ReadLines(@".\data\day7\sample.txt");
+
+    private enum HandType
+    {
+        FiveOfAKind = 6,
+        FourOfAKind = 5,
+        FullHouse = 4,
+        ThreeOfAKind = 3,
+        TwoPair = 2,
+        OnePair = 1,
+        HighCard = 0
+    }
+
+    public int GetPart1Answer(IEnumerable<string> input) =>
+        input.Select(l => parseHandLine(l))
+            .OrderBy(line => line.hand.Type)
+            .ThenBy(h => h.mappedHand)
+            .Select((h, i) => h.Bid * (i + 1))
+            .Sum();
+
+    public int? GetPart2Answer(IEnumerable<string> input) =>
+        input.Select(l => parseHandLine(l, true))
+            .OrderBy(line => line.hand.Type)
+            .ThenBy(h => h.mappedHand)
+            .Select((h, i) => h.Bid * (i + 1))
+            .Sum();
+
+    private (Hand hand, string mappedHand, int Bid) parseHandLine(string line, bool isPart2 = false)
+    {
+        var items = line.Split(' ');
+        var hand = new Hand(items[0], getHand(items[0], isPart2));
+        return (hand, replaceNotation(hand.Cards, isPart2), int.Parse(items[1]));
+    }
+    
+    private readonly record struct Hand(string Cards, HandType Type);
+
+    private Regex _replaceLetters = new("A|K|T|J");
+
+    private string replaceNotation(string hand, bool jokersWild = false) =>
+        _replaceLetters.Replace(hand, (m) => m.Value switch {
+            "A" => "Z",
+            "K" => "Y",
+            "T" => "A",
+            "J" when jokersWild => "0",
+            _ => m.Value
+        });
+
+    private HandType getHand(string hand, bool jokersWild = false)
+    {
+        var handToProcess = jokersWild ? hand.Replace("J", "") : hand;
+
+        // handle edge case of 5 jokers
+        if (jokersWild && handToProcess.Length == 0)
+        {
+            return HandType.FiveOfAKind;
+        }
+
+        var jokerCount = hand.Length - handToProcess.Length;
+
+        var charCounts = handToProcess.GroupBy(c => c).Select(g => g.Count()).ToArray();
+
+        return charCounts.Length switch {
+            1 => HandType.FiveOfAKind,
+            2 => charCounts.Contains(4 - jokerCount) ? HandType.FourOfAKind : HandType.FullHouse,
+            3 => charCounts.Contains(3 - jokerCount) ? HandType.ThreeOfAKind : HandType.TwoPair,
+            4 => HandType.OnePair,
+            _ => HandType.HighCard
+        };
+    }
+
+}

--- a/2023/C#/tests/Day7.cs
+++ b/2023/C#/tests/Day7.cs
@@ -1,0 +1,39 @@
+using Xunit;
+using FluentAssertions;
+
+public class Day7Tests
+{
+    Day7 _sut = new Day7();
+
+    [Fact]
+    public void Part1Answer_ShouldBeCorrect_WhenSampleData()
+    {
+        var answer = _sut.GetPart1Answer(_sut.SampleData);
+
+        answer.Should().Be(6440);
+    }
+
+    [Fact]
+    public void Part1Answer_ShouldBeCorrect_WhenInputData()
+    {
+        var answer = _sut.GetPart1Answer(_sut.InputData);
+
+        answer.Should().Be(248559379);
+    }
+
+    [Fact]
+    public void Part2Answer_ShouldBeCorrect_WhenSampleData()
+    {
+        var answer = _sut.GetPart2Answer(_sut.SampleData);
+
+        answer.Should().Be(5905);
+    }
+
+    [Fact]
+    public void Part2Answer_ShouldBeCorrect_WhenInputData()
+    {
+        var answer = _sut.GetPart2Answer(_sut.InputData);
+
+        answer.Should().Be(249631254);
+    } 
+}


### PR DESCRIPTION
Not too tricky today - I toyed with trying to use a pure regex solution for part 1, but decided against it as I wasn't sure of the perf characteristics of sorting each string and then repeatedly testing 6 regular expressions featuring various levels of backreferencing. 

I settled instead for using a form of distinct (we still need the count of duplicate letters in two cases) - by grouping based on letter we can then determine most of the hands simply by referencing the number of groups. The two ties (Four of a kind and Full House, and Three of a Kind and Two pair) just require us to check the count of the groups for a particular value to distinguish them. For card strength I simply replaced the card notation into a corresponding alphabet and then just relied on string sorting.

This worked nicely for part 2, and after adding some overloads to handle translating jokers into 0 for strength and including the count of jokers in hand type tiebreaks, it was all working in a reasonable speed. I could probably use `Span<char>` and `ReadOnlySpan<char>` to reduce the memory footprint of all those string allocations and iterating, but it's not a production system 😉 

Also, I'm pleased I spotted the "all jokers" edge case before attempting to run the full input. Not sure what deck of cards these Elves are playing with that lets 5 of a kind be a thing!